### PR TITLE
Avoid automated deployment when testing PRs

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,6 +3,16 @@
 DEPLOY_FROM="master"
 DEPLOY_TO="gh-pages"
 
+# Do not deploy when building pull requests.
+# If this build comes from an unmerged pull request, it will be ignored.
+# In order to have automated deployemnts, you must have builds active on
+# pushes (merges) in your Travis settings for the repo (Travis dashboard).
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]
+then
+  echo "Skipping deployment: we do not deploy Pull Request test builds."
+  exit 0
+fi
+
 # Only deploy from the configured branch
 if [ $TRAVIS_BRANCH == $DEPLOY_FROM ]
 then


### PR DESCRIPTION
The build script has a major problem: when building a PR from any branch branch into `master` (DEPLOY_TO), the deployment script will go through the deployment process, even before the PR is merged.

These changes make the script check if we're dealing with a PR or not and thus the build script will only proceed after the PR to `master`(DEPLOY_TO) is merged. Of course, in order for this to happen, Travis  builds on every push must be enabled in the repository configuration in the dashboard.
#### Notes:
- First noticed and already fixed in marzeelabs.org
